### PR TITLE
Always delete daily analytics branch, even on failure

### DIFF
--- a/.github/workflows/analytics.yml
+++ b/.github/workflows/analytics.yml
@@ -57,6 +57,7 @@ jobs:
         run: |
           if [[ -n "$(git status --porcelain)" ]]; then
             BRANCH="analytics-$(date +%s)"
+            trap 'gh api -X DELETE "repos/${{ github.repository }}/git/refs/heads/$BRANCH" --silent 2>/dev/null || true' EXIT # Always delete the branch, even on early exit or failure
             git config user.name "UltralyticsAssistant"
             git config user.email "web@ultralytics.com"
             git checkout -b "$BRANCH"


### PR DESCRIPTION
## Summary
- The `Update Analytics` workflow pushes `analytics-<timestamp>` before `gh pr create` / `sleep 300` / `gh pr merge --delete-branch`. Any failure in between (network blip, runner cancel, sleep timeout) leaves the branch orphaned on origin — `--delete-branch` only runs on the happy path.
- Add a bash `EXIT` trap right after the branch name is assigned: it deletes the remote branch via `gh api` regardless of how the script terminates. Idempotent — when `gh pr merge --delete-branch` already removed it, the API call returns 404, swallowed by `|| true`.

## Test plan
- [ ] Trigger workflow via `workflow_dispatch` with changes — verify the branch is deleted after a successful merge.
- [ ] Simulate a failure mid-sleep (cancel run) — verify the branch is deleted on workflow cancel.

## 🛠️ PR Summary

<sub>Made with ❤️ by [Ultralytics Actions](https://www.ultralytics.com/actions)</sub>

### 🌟 Summary
🧹 This PR improves the analytics GitHub Actions workflow by ensuring temporary branches are always cleaned up automatically, even if the job exits early or fails.

### 📊 Key Changes
- Added a `trap` command in `.github/workflows/analytics.yml` to automatically delete the temporary analytics branch on workflow exit.
- The cleanup now runs not only after successful execution, but also on early termination or failure.
- The deleted branch is the dynamically created branch named like `analytics-<timestamp>`.

### 🎯 Purpose & Impact
- Reduces repository clutter by preventing leftover temporary branches. ✨
- Makes the analytics automation more reliable and self-cleaning. 🔄
- Helps maintainers avoid manual cleanup work when workflows fail. 🙌
- Lowers the chance of stale branches causing confusion or clutter in repository management. 🛠️