### PR TITLE
Write analytics JSON readably

### DIFF
--- a/data/github.json
+++ b/data/github.json
@@ -1,1 +1,372 @@
-{"org":"ultralytics","total_stars":132520,"total_forks":33039,"total_issues":25501,"total_pull_requests":14392,"total_contributors":1033,"public_repos":45,"timestamp":"2026-06-11T03:20:51.500112Z","repos":[{"name":"ultralytics","stars":58259,"forks":11167,"issues":12745,"pull_requests":6351,"contributors":366},{"name":"yolov5","stars":57506,"forks":17465,"issues":9443,"pull_requests":2971,"contributors":347},{"name":"yolov3","stars":10570,"forks":3432,"issues":1825,"pull_requests":553,"contributors":55},{"name":"JSON2YOLO","stars":1218,"forks":262,"issues":65,"pull_requests":66,"contributors":8},{"name":"assets","stars":606,"forks":49,"issues":9,"pull_requests":144,"contributors":19},{"name":"yolo-ios-app","stars":478,"forks":92,"issues":51,"pull_requests":223,"contributors":11},{"name":"yolo-flutter-app","stars":437,"forks":163,"issues":234,"pull_requests":293,"contributors":28},{"name":"xview-yolov3","stars":333,"forks":58,"issues":31,"pull_requests":45,"contributors":5},{"name":"flickr_scraper","stars":285,"forks":67,"issues":11,"pull_requests":38,"contributors":4},{"name":"hub","stars":235,"forks":18,"issues":1022,"pull_requests":242,"contributors":11},{"name":"notebooks","stars":221,"forks":52,"issues":0,"pull_requests":95,"contributors":5},{"name":"velocity","stars":129,"forks":22,"issues":10,"pull_requests":132,"contributors":3},{"name":"docs","stars":119,"forks":15,"issues":6,"pull_requests":309,"contributors":10},{"name":"actions","stars":113,"forks":18,"issues":11,"pull_requests":754,"contributors":13},{"name":"llm","stars":100,"forks":4,"issues":1,"pull_requests":98,"contributors":7},{"name":"inference","stars":92,"forks":14,"issues":8,"pull_requests":231,"contributors":5},{"name":"hub-sdk","stars":87,"forks":4,"issues":3,"pull_requests":304,"contributors":12},{"name":"stars","stars":83,"forks":5,"issues":0,"pull_requests":346,"contributors":6},{"name":"kinect","stars":76,"forks":8,"issues":2,"pull_requests":24,"contributors":3},{"name":"mkdocs","stars":74,"forks":2,"issues":7,"pull_requests":185,"contributors":7},{"name":"wave","stars":72,"forks":6,"issues":1,"pull_requests":43,"contributors":3},{"name":"template","stars":71,"forks":12,"issues":1,"pull_requests":84,"contributors":5},{"name":"handbook","stars":70,"forks":29,"issues":3,"pull_requests":294,"contributors":31},{"name":".github","stars":69,"forks":8,"issues":4,"pull_requests":63,"contributors":3},{"name":"functions-matlab","stars":68,"forks":18,"issues":2,"pull_requests":24,"contributors":4},{"name":"iSky","stars":63,"forks":7,"issues":0,"pull_requests":20,"contributors":3},{"name":"source-trace","stars":63,"forks":2,"issues":0,"pull_requests":18,"contributors":3},{"name":"xview-docker","stars":61,"forks":2,"issues":0,"pull_requests":27,"contributors":3},{"name":"mnist","stars":60,"forks":5,"issues":0,"pull_requests":25,"contributors":3},{"name":"petsys","stars":59,"forks":2,"issues":4,"pull_requests":28,"contributors":3},{"name":"autoimport","stars":59,"forks":5,"issues":1,"pull_requests":45,"contributors":4},{"name":"replicate","stars":59,"forks":4,"issues":0,"pull_requests":29,"contributors":4},{"name":"pre-commit","stars":58,"forks":1,"issues":0,"pull_requests":27,"contributors":3},{"name":"template-rust","stars":58,"forks":3,"issues":0,"pull_requests":55,"contributors":4},{"name":"agm2015","stars":57,"forks":1,"issues":0,"pull_requests":23,"contributors":3},{"name":"miniTimeCube","stars":57,"forks":2,"issues":0,"pull_requests":22,"contributors":3},{"name":"msvm","stars":56,"forks":3,"issues":0,"pull_requests":22,"contributors":3},{"name":"ntc","stars":56,"forks":1,"issues":0,"pull_requests":23,"contributors":3},{"name":"nudar","stars":56,"forks":2,"issues":0,"pull_requests":24,"contributors":3},{"name":"magellan","stars":55,"forks":2,"issues":0,"pull_requests":20,"contributors":3},{"name":"profile","stars":55,"forks":1,"issues":0,"pull_requests":8,"contributors":2},{"name":"yoloe_data_engine","stars":55,"forks":2,"issues":0,"pull_requests":2,"contributors":2},{"name":"ios_screenshots","stars":54,"forks":2,"issues":1,"pull_requests":23,"contributors":3},{"name":"sandd","stars":54,"forks":1,"issues":0,"pull_requests":20,"contributors":3},{"name":"ultralytics-ios-podspecs","stars":54,"forks":1,"issues":0,"pull_requests":19,"contributors":4}]}
+{
+  "org": "ultralytics",
+  "total_stars": 132520,
+  "total_forks": 33039,
+  "total_issues": 25501,
+  "total_pull_requests": 14392,
+  "total_contributors": 1033,
+  "public_repos": 45,
+  "timestamp": "2026-06-11T03:20:51.500112Z",
+  "repos": [
+    {
+      "name": "ultralytics",
+      "stars": 58259,
+      "forks": 11167,
+      "issues": 12745,
+      "pull_requests": 6351,
+      "contributors": 366
+    },
+    {
+      "name": "yolov5",
+      "stars": 57506,
+      "forks": 17465,
+      "issues": 9443,
+      "pull_requests": 2971,
+      "contributors": 347
+    },
+    {
+      "name": "yolov3",
+      "stars": 10570,
+      "forks": 3432,
+      "issues": 1825,
+      "pull_requests": 553,
+      "contributors": 55
+    },
+    {
+      "name": "JSON2YOLO",
+      "stars": 1218,
+      "forks": 262,
+      "issues": 65,
+      "pull_requests": 66,
+      "contributors": 8
+    },
+    {
+      "name": "assets",
+      "stars": 606,
+      "forks": 49,
+      "issues": 9,
+      "pull_requests": 144,
+      "contributors": 19
+    },
+    {
+      "name": "yolo-ios-app",
+      "stars": 478,
+      "forks": 92,
+      "issues": 51,
+      "pull_requests": 223,
+      "contributors": 11
+    },
+    {
+      "name": "yolo-flutter-app",
+      "stars": 437,
+      "forks": 163,
+      "issues": 234,
+      "pull_requests": 293,
+      "contributors": 28
+    },
+    {
+      "name": "xview-yolov3",
+      "stars": 333,
+      "forks": 58,
+      "issues": 31,
+      "pull_requests": 45,
+      "contributors": 5
+    },
+    {
+      "name": "flickr_scraper",
+      "stars": 285,
+      "forks": 67,
+      "issues": 11,
+      "pull_requests": 38,
+      "contributors": 4
+    },
+    {
+      "name": "hub",
+      "stars": 235,
+      "forks": 18,
+      "issues": 1022,
+      "pull_requests": 242,
+      "contributors": 11
+    },
+    {
+      "name": "notebooks",
+      "stars": 221,
+      "forks": 52,
+      "issues": 0,
+      "pull_requests": 95,
+      "contributors": 5
+    },
+    {
+      "name": "velocity",
+      "stars": 129,
+      "forks": 22,
+      "issues": 10,
+      "pull_requests": 132,
+      "contributors": 3
+    },
+    {
+      "name": "docs",
+      "stars": 119,
+      "forks": 15,
+      "issues": 6,
+      "pull_requests": 309,
+      "contributors": 10
+    },
+    {
+      "name": "actions",
+      "stars": 113,
+      "forks": 18,
+      "issues": 11,
+      "pull_requests": 754,
+      "contributors": 13
+    },
+    {
+      "name": "llm",
+      "stars": 100,
+      "forks": 4,
+      "issues": 1,
+      "pull_requests": 98,
+      "contributors": 7
+    },
+    {
+      "name": "inference",
+      "stars": 92,
+      "forks": 14,
+      "issues": 8,
+      "pull_requests": 231,
+      "contributors": 5
+    },
+    {
+      "name": "hub-sdk",
+      "stars": 87,
+      "forks": 4,
+      "issues": 3,
+      "pull_requests": 304,
+      "contributors": 12
+    },
+    {
+      "name": "stars",
+      "stars": 83,
+      "forks": 5,
+      "issues": 0,
+      "pull_requests": 346,
+      "contributors": 6
+    },
+    {
+      "name": "kinect",
+      "stars": 76,
+      "forks": 8,
+      "issues": 2,
+      "pull_requests": 24,
+      "contributors": 3
+    },
+    {
+      "name": "mkdocs",
+      "stars": 74,
+      "forks": 2,
+      "issues": 7,
+      "pull_requests": 185,
+      "contributors": 7
+    },
+    {
+      "name": "wave",
+      "stars": 72,
+      "forks": 6,
+      "issues": 1,
+      "pull_requests": 43,
+      "contributors": 3
+    },
+    {
+      "name": "template",
+      "stars": 71,
+      "forks": 12,
+      "issues": 1,
+      "pull_requests": 84,
+      "contributors": 5
+    },
+    {
+      "name": "handbook",
+      "stars": 70,
+      "forks": 29,
+      "issues": 3,
+      "pull_requests": 294,
+      "contributors": 31
+    },
+    {
+      "name": ".github",
+      "stars": 69,
+      "forks": 8,
+      "issues": 4,
+      "pull_requests": 63,
+      "contributors": 3
+    },
+    {
+      "name": "functions-matlab",
+      "stars": 68,
+      "forks": 18,
+      "issues": 2,
+      "pull_requests": 24,
+      "contributors": 4
+    },
+    {
+      "name": "iSky",
+      "stars": 63,
+      "forks": 7,
+      "issues": 0,
+      "pull_requests": 20,
+      "contributors": 3
+    },
+    {
+      "name": "source-trace",
+      "stars": 63,
+      "forks": 2,
+      "issues": 0,
+      "pull_requests": 18,
+      "contributors": 3
+    },
+    {
+      "name": "xview-docker",
+      "stars": 61,
+      "forks": 2,
+      "issues": 0,
+      "pull_requests": 27,
+      "contributors": 3
+    },
+    {
+      "name": "mnist",
+      "stars": 60,
+      "forks": 5,
+      "issues": 0,
+      "pull_requests": 25,
+      "contributors": 3
+    },
+    {
+      "name": "petsys",
+      "stars": 59,
+      "forks": 2,
+      "issues": 4,
+      "pull_requests": 28,
+      "contributors": 3
+    },
+    {
+      "name": "autoimport",
+      "stars": 59,
+      "forks": 5,
+      "issues": 1,
+      "pull_requests": 45,
+      "contributors": 4
+    },
+    {
+      "name": "replicate",
+      "stars": 59,
+      "forks": 4,
+      "issues": 0,
+      "pull_requests": 29,
+      "contributors": 4
+    },
+    {
+      "name": "pre-commit",
+      "stars": 58,
+      "forks": 1,
+      "issues": 0,
+      "pull_requests": 27,
+      "contributors": 3
+    },
+    {
+      "name": "template-rust",
+      "stars": 58,
+      "forks": 3,
+      "issues": 0,
+      "pull_requests": 55,
+      "contributors": 4
+    },
+    {
+      "name": "agm2015",
+      "stars": 57,
+      "forks": 1,
+      "issues": 0,
+      "pull_requests": 23,
+      "contributors": 3
+    },
+    {
+      "name": "miniTimeCube",
+      "stars": 57,
+      "forks": 2,
+      "issues": 0,
+      "pull_requests": 22,
+      "contributors": 3
+    },
+    {
+      "name": "msvm",
+      "stars": 56,
+      "forks": 3,
+      "issues": 0,
+      "pull_requests": 22,
+      "contributors": 3
+    },
+    {
+      "name": "ntc",
+      "stars": 56,
+      "forks": 1,
+      "issues": 0,
+      "pull_requests": 23,
+      "contributors": 3
+    },
+    {
+      "name": "nudar",
+      "stars": 56,
+      "forks": 2,
+      "issues": 0,
+      "pull_requests": 24,
+      "contributors": 3
+    },
+    {
+      "name": "magellan",
+      "stars": 55,
+      "forks": 2,
+      "issues": 0,
+      "pull_requests": 20,
+      "contributors": 3
+    },
+    {
+      "name": "profile",
+      "stars": 55,
+      "forks": 1,
+      "issues": 0,
+      "pull_requests": 8,
+      "contributors": 2
+    },
+    {
+      "name": "yoloe_data_engine",
+      "stars": 55,
+      "forks": 2,
+      "issues": 0,
+      "pull_requests": 2,
+      "contributors": 2
+    },
+    {
+      "name": "ios_screenshots",
+      "stars": 54,
+      "forks": 2,
+      "issues": 1,
+      "pull_requests": 23,
+      "contributors": 3
+    },
+    {
+      "name": "sandd",
+      "stars": 54,
+      "forks": 1,
+      "issues": 0,
+      "pull_requests": 20,
+      "contributors": 3
+    },
+    {
+      "name": "ultralytics-ios-podspecs",
+      "stars": 54,
+      "forks": 1,
+      "issues": 0,
+      "pull_requests": 19,
+      "contributors": 4
+    }
+  ]
+}

--- a/data/google_analytics.json
+++ b/data/google_analytics.json
@@ -1,1 +1,36 @@
-{"property_id":"371754141","timestamp":"2026-06-10T03:21:47.155165Z","periods":{"1d":{"active_users":745443,"sessions":5478287,"events":3432590603,"avg_session_duration":3795.7303059712353},"7d":{"active_users":3849390,"sessions":38596024,"events":24558009090,"avg_session_duration":3482.437116149985},"30d":{"active_users":15819546,"sessions":164828953,"events":102453920657,"avg_session_duration":3341.0778899791762},"90d":{"active_users":43974348,"sessions":491051939,"events":281017903042,"avg_session_duration":3252.3511218715084},"365d":{"active_users":119898849,"sessions":3130801257,"events":895171991247,"avg_session_duration":1774.434136246092}}}
+{
+  "property_id": "371754141",
+  "timestamp": "2026-06-10T03:21:47.155165Z",
+  "periods": {
+    "1d": {
+      "active_users": 745443,
+      "sessions": 5478287,
+      "events": 3432590603,
+      "avg_session_duration": 3795.7303059712353
+    },
+    "7d": {
+      "active_users": 3849390,
+      "sessions": 38596024,
+      "events": 24558009090,
+      "avg_session_duration": 3482.437116149985
+    },
+    "30d": {
+      "active_users": 15819546,
+      "sessions": 164828953,
+      "events": 102453920657,
+      "avg_session_duration": 3341.0778899791762
+    },
+    "90d": {
+      "active_users": 43974348,
+      "sessions": 491051939,
+      "events": 281017903042,
+      "avg_session_duration": 3252.3511218715084
+    },
+    "365d": {
+      "active_users": 119898849,
+      "sessions": 3130801257,
+      "events": 895171991247,
+      "avg_session_duration": 1774.434136246092
+    }
+  }
+}

--- a/data/platform.json
+++ b/data/platform.json
@@ -1,1 +1,9 @@
-{"total_projects":14149,"total_datasets":36195,"total_images":170254367,"total_models":30633,"total_exports":9631,"total_annotations":833791590,"timestamp":"2026-06-11T03:22:22.890986Z"}
+{
+  "total_projects": 14149,
+  "total_datasets": 36195,
+  "total_images": 170254367,
+  "total_models": 30633,
+  "total_exports": 9631,
+  "total_annotations": 833791590,
+  "timestamp": "2026-06-11T03:22:22.890986Z"
+}

--- a/data/pypi.json
+++ b/data/pypi.json
@@ -1,1 +1,49 @@
-{"total_downloads":283025339,"total_last_month":15898667,"timestamp":"2026-06-11T03:21:16.332726Z","packages":[{"package":"ultralytics","last_day":0,"last_week":1696984,"last_month":9483022,"total":194486042},{"package":"ultralytics-actions","last_day":0,"last_week":868,"last_month":3255,"total":256121},{"package":"ultralytics-thop","last_day":0,"last_week":1287634,"last_month":6368317,"total":86774882},{"package":"hub-sdk","last_day":0,"last_week":5564,"last_month":27864,"total":1211394},{"package":"mkdocs-ultralytics-plugin","last_day":0,"last_week":1707,"last_month":16123,"total":291598},{"package":"ultralytics-autoimport","last_day":0,"last_week":47,"last_month":86,"total":5302}]}
+{
+  "total_downloads": 283025339,
+  "total_last_month": 15898667,
+  "timestamp": "2026-06-11T03:21:16.332726Z",
+  "packages": [
+    {
+      "package": "ultralytics",
+      "last_day": 0,
+      "last_week": 1696984,
+      "last_month": 9483022,
+      "total": 194486042
+    },
+    {
+      "package": "ultralytics-actions",
+      "last_day": 0,
+      "last_week": 868,
+      "last_month": 3255,
+      "total": 256121
+    },
+    {
+      "package": "ultralytics-thop",
+      "last_day": 0,
+      "last_week": 1287634,
+      "last_month": 6368317,
+      "total": 86774882
+    },
+    {
+      "package": "hub-sdk",
+      "last_day": 0,
+      "last_week": 5564,
+      "last_month": 27864,
+      "total": 1211394
+    },
+    {
+      "package": "mkdocs-ultralytics-plugin",
+      "last_day": 0,
+      "last_week": 1707,
+      "last_month": 16123,
+      "total": 291598
+    },
+    {
+      "package": "ultralytics-autoimport",
+      "last_day": 0,
+      "last_week": 47,
+      "last_month": 86,
+      "total": 5302
+    }
+  ]
+}

--- a/data/reddit.json
+++ b/data/reddit.json
@@ -1,1 +1,5 @@
-{"subreddit":"ultralytics","subscribers":3100,"timestamp":"2026-06-11T03:22:21.569720Z"}
+{
+  "subreddit": "ultralytics",
+  "subscribers": 3100,
+  "timestamp": "2026-06-11T03:22:21.569720Z"
+}

--- a/data/summary.json
+++ b/data/summary.json
@@ -1,1 +1,17 @@
-{"total_stars":132520,"total_forks":33039,"total_issues":25501,"total_pull_requests":14392,"total_downloads":283025339,"events_per_day":3122421145,"total_contributors":1033,"reddit_subscribers":3100,"platform_datasets":36195,"platform_annotations":833791590,"platform_images":170254367,"platform_projects":14149,"platform_models":30633,"platform_exports":9631,"timestamp":"2026-06-11T03:22:22.892571Z"}
+{
+  "total_stars": 132520,
+  "total_forks": 33039,
+  "total_issues": 25501,
+  "total_pull_requests": 14392,
+  "total_downloads": 283025339,
+  "events_per_day": 3122421145,
+  "total_contributors": 1033,
+  "reddit_subscribers": 3100,
+  "platform_datasets": 36195,
+  "platform_annotations": 833791590,
+  "platform_images": 170254367,
+  "platform_projects": 14149,
+  "platform_models": 30633,
+  "platform_exports": 9631,
+  "timestamp": "2026-06-11T03:22:22.892571Z"
+}

--- a/utils.py
+++ b/utils.py
@@ -91,13 +91,13 @@ def _sanitize_floats(obj):
 
 
 def write_json(path: Path, data: dict) -> None:
-    """Write compact JSON with trailing newline. Sanitizes NaN/Inf to 0 if present."""
+    """Write readable JSON with trailing newline. Sanitizes NaN/Inf to 0 if present."""
     path.parent.mkdir(parents=True, exist_ok=True)
     try:
-        text = json.dumps(data, ensure_ascii=False, separators=(",", ":"), allow_nan=False)
+        text = json.dumps(data, ensure_ascii=False, indent=2, allow_nan=False)
     except ValueError:
         print(f"Warning: Sanitizing NaN/Inf values before writing {path.name}")
-        text = json.dumps(_sanitize_floats(data), ensure_ascii=False, separators=(",", ":"), allow_nan=False)
+        text = json.dumps(_sanitize_floats(data), ensure_ascii=False, indent=2, allow_nan=False)
     path.write_text(text + "\n", encoding="utf-8")
 
 


### PR DESCRIPTION
## Summary
- write generated analytics JSON with two-space indentation instead of compact separators
- reformat the existing data/*.json files without changing parsed content

## Why
Analytics PRs are generated by automation, and compact one-line JSON is hard to review. The shared formatter regression is fixed in ultralytics/actions#768, but this makes the stars generator produce readable JSON directly instead of relying on a follow-up formatter commit.

## Tests
- python -m compileall fetch_stats.py utils.py count_stars.py
- npx --yes prettier@3.6.2 --check --print-width 120 "data/*.json"
- parsed-content equality check against HEAD for all data/*.json

## 🛠️ PR Summary

<sub>Made with ❤️ by [Ultralytics Actions](https://www.ultralytics.com/actions)</sub>

### 🌟 Summary
✨ This PR reformats all generated JSON data files to be human-readable, making repository metrics and analytics much easier to inspect, review, and debug.

### 📊 Key Changes
- 🧹 Updated `write_json()` in `utils.py` to output pretty-printed JSON using indentation instead of compact single-line JSON.
- 📝 Adjusted the function description to reflect that it now writes **readable JSON** rather than compact JSON.
- 🛡️ Kept existing safety behavior that sanitizes invalid float values like `NaN` or `Inf` before writing JSON.
- 📂 Regenerated multiple data files in `data/` with the new format, including:
  - `github.json`
  - `google_analytics.json`
  - `platform.json`
  - `pypi.json`
  - `reddit.json`
  - `summary.json`

### 🎯 Purpose & Impact
- 👀 Makes metrics files much easier for developers and contributors to read directly in GitHub diffs and local editors.
- 🔍 Improves reviewability by showing structured changes clearly instead of dense one-line JSON blobs.
- 🛠️ Simplifies debugging and manual inspection of analytics, platform, and package statistics.
- 📦 Does **not** change the underlying data values or schema—this is a formatting and maintainability improvement, not a feature change.
- 🤝 Helps both technical and non-technical users better understand repository and usage stats at a glance.