### PR TITLE
Bump actions/checkout from v6 to v7 in /.github/workflows

### DIFF
--- a/.github/workflows/analytics.yml
+++ b/.github/workflows/analytics.yml
@@ -38,7 +38,7 @@ jobs:
   stats:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v6
+      - uses: actions/checkout@v7
       - uses: actions/setup-python@v6
         with:
           python-version: "3.x"


### PR DESCRIPTION
Bump actions/checkout from v6 to v7 in /.github/workflows

This PR updates GitHub Actions references in this repository.

Examples:
- Branch: `actions/checkout@main` stays on `@main`
- Major tag: `actions/checkout@v4` updates to `@v5`
- Specific tag: `astral-sh/setup-uv@v0.5.0` updates to `@v0.9.4`
- SHA pinned: `actions/checkout@<sha> # v4.1.0` updates to the latest release SHA and tag comment

<sub>Made with ❤️ by [Ultralytics Actions](https://www.ultralytics.com/actions)</sub>

## 🛠️ PR Summary

<sub>Made with ❤️ by [Ultralytics Actions](https://www.ultralytics.com/actions)</sub>

### 🌟 Summary
🔄 This PR updates the GitHub Actions checkout step in the analytics workflow from `actions/checkout@v6` to `actions/checkout@v7`.

### 📊 Key Changes
- Upgraded the checkout action in `.github/workflows/analytics.yml`
  - Changed `actions/checkout@v6` → `actions/checkout@v7`
- No application code or analytics logic was modified
- The change only affects the GitHub Actions CI workflow environment ⚙️

### 🎯 Purpose & Impact
- Keeps the repository’s automation up to date with the latest GitHub Action version 📦
- May improve workflow reliability, compatibility, and access to upstream fixes
- Low-risk maintenance update since it does not change product behavior or analytics results ✅
- Helps ensure the project stays aligned with current GitHub Actions best practices 🚀