### PR TITLE
Use shared setup-uv action everywhere

### DIFF
--- a/.github/workflows/analytics.yml
+++ b/.github/workflows/analytics.yml
@@ -43,6 +43,9 @@ jobs:
         with:
           python-version: "3.x"
       - uses: ultralytics/actions/setup-uv@main
+        with:
+          enable-cache: true
+          cache-dependency-glob: "requirements.txt"
       - run: uv pip install --system -r requirements.txt
       - name: Fetch analytics
         env:

--- a/.github/workflows/analytics.yml
+++ b/.github/workflows/analytics.yml
@@ -42,7 +42,7 @@ jobs:
       - uses: actions/setup-python@v6
         with:
           python-version: "3.x"
-      - uses: astral-sh/setup-uv@v7
+      - uses: ultralytics/actions/setup-uv@main
       - run: uv pip install --system -r requirements.txt
       - name: Fetch analytics
         env:


### PR DESCRIPTION
## Summary
- replace the Astral uv setup step with the shared retried owner
- preserve the daily analytics dependency cache explicitly, keyed by requirements.txt

Reused: ultralytics/actions/setup-uv@main is the single latest-uv installer and opt-in cache owner.

Deleted: the direct astral-sh/setup-uv dependency. The three cache-input lines are required because the shared owner intentionally defaults caching off while this daily hosted job previously used Astral automatic caching.

## Validation
- zero astral-sh/setup-uv occurrences
- the setup caller is exactly ultralytics/actions/setup-uv@main
- actionlint .github/workflows/analytics.yml
- git diff --check
- shared owner passed cache-enabled Windows, Ubuntu, and macOS CI

## 🛠️ PR Summary

<sub>Made with ❤️ by [Ultralytics Actions](https://www.ultralytics.com/actions)</sub>

### 🌟 Summary

Updates the analytics workflow to use Ultralytics’ shared `setup-uv` action with dependency caching ⚡

### 📊 Key Changes

- Replaces `astral-sh/setup-uv@v7` with `ultralytics/actions/setup-uv@main`.
- Enables caching for installed dependencies.
- Configures the cache to refresh based on changes to `requirements.txt`.

### 🎯 Purpose & Impact

- Speeds up GitHub Actions analytics runs by reusing cached Python dependencies 🚀
- Helps keep workflow configuration consistent with other Ultralytics repositories.
- Automatically invalidates the cache when project dependencies change, improving reliability.