### PR TITLE
Bump actions/setup-python from v6 to v7 in /.github/workflows

### DIFF
--- a/.github/workflows/analytics.yml
+++ b/.github/workflows/analytics.yml
@@ -39,7 +39,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v7
-      - uses: actions/setup-python@v6
+      - uses: actions/setup-python@v7
         with:
           python-version: "3.x"
       - uses: ultralytics/actions/setup-uv@main


### PR DESCRIPTION
Bump actions/setup-python from v6 to v7 in /.github/workflows

This PR updates GitHub Actions references in this repository.

Examples:
- Branch: `actions/checkout@main` stays on `@main`
- Major tag: `actions/checkout@v4` updates to `@v5`
- Specific tag: `astral-sh/setup-uv@v0.5.0` updates to `@v0.9.4`
- SHA pinned: `actions/checkout@<sha> # v4.1.0` updates to the latest release SHA and tag comment

<sub>Made with ❤️ by [Ultralytics Actions](https://www.ultralytics.com/actions)</sub>

## 🛠️ PR Summary

<sub>Made with ❤️ by [Ultralytics Actions](https://www.ultralytics.com/actions)</sub>

### 🌟 Summary

⚙️ Updates the analytics workflow to use the latest `actions/setup-python` release.

### 📊 Key Changes

- Replaces `actions/setup-python@v6` with `actions/setup-python@v7` in `.github/workflows/analytics.yml`.
- Keeps the existing Python 3.x configuration and workflow steps unchanged.

### 🎯 Purpose & Impact

- ✅ Benefits from the latest improvements, fixes, and compatibility updates in the Python setup action.
- 🚀 Helps keep the analytics CI workflow current and reliable.
- 🔒 No expected changes to application behavior or user-facing functionality.