### PR TITLE
Update Ultralytics analytics

### DIFF
--- a/data/github.json
+++ b/data/github.json
@@ -1,40 +1,40 @@
 {
   "org": "ultralytics",
-  "total_stars": 134599,
-  "total_forks": 33352,
-  "total_issues": 25608,
-  "total_pull_requests": 15505,
-  "total_contributors": 1089,
+  "total_stars": 134668,
+  "total_forks": 33364,
+  "total_issues": 25611,
+  "total_pull_requests": 15545,
+  "total_contributors": 1092,
   "public_repos": 48,
-  "timestamp": "2026-07-24T03:12:23.893087Z",
+  "timestamp": "2026-07-25T03:11:24.234970Z",
   "repos": [
     {
       "name": "ultralytics",
-      "stars": 59800,
-      "forks": 11432,
-      "issues": 12840,
-      "pull_requests": 6843,
-      "contributors": 408
+      "stars": 59844,
+      "forks": 11446,
+      "issues": 12843,
+      "pull_requests": 6865,
+      "contributors": 409
     },
     {
       "name": "yolov5",
-      "stars": 57726,
-      "forks": 17470,
+      "stars": 57739,
+      "forks": 17469,
       "issues": 9442,
       "pull_requests": 2991,
-      "contributors": 348
+      "contributors": 349
     },
     {
       "name": "yolov3",
-      "stars": 10586,
-      "forks": 3434,
+      "stars": 10587,
+      "forks": 3433,
       "issues": 1826,
       "pull_requests": 574,
       "contributors": 55
     },
     {
       "name": "JSON2YOLO",
-      "stars": 1222,
+      "stars": 1224,
       "forks": 263,
       "issues": 65,
       "pull_requests": 74,
@@ -42,7 +42,7 @@
     },
     {
       "name": "assets",
-      "stars": 640,
+      "stars": 641,
       "forks": 51,
       "issues": 9,
       "pull_requests": 158,
@@ -53,7 +53,7 @@
       "stars": 497,
       "forks": 98,
       "issues": 51,
-      "pull_requests": 251,
+      "pull_requests": 253,
       "contributors": 11
     },
     {
@@ -61,7 +61,7 @@
       "stars": 463,
       "forks": 173,
       "issues": 238,
-      "pull_requests": 331,
+      "pull_requests": 333,
       "contributors": 28
     },
     {
@@ -86,11 +86,11 @@
       "forks": 19,
       "issues": 1025,
       "pull_requests": 254,
-      "contributors": 11
+      "contributors": 12
     },
     {
       "name": "notebooks",
-      "stars": 227,
+      "stars": 228,
       "forks": 53,
       "issues": 0,
       "pull_requests": 105,
@@ -106,10 +106,10 @@
     },
     {
       "name": "inference",
-      "stars": 126,
+      "stars": 128,
       "forks": 16,
       "issues": 11,
-      "pull_requests": 340,
+      "pull_requests": 346,
       "contributors": 5
     },
     {
@@ -125,12 +125,12 @@
       "stars": 117,
       "forks": 18,
       "issues": 12,
-      "pull_requests": 820,
+      "pull_requests": 826,
       "contributors": 14
     },
     {
       "name": "llm",
-      "stars": 104,
+      "stars": 106,
       "forks": 5,
       "issues": 1,
       "pull_requests": 106,
@@ -149,7 +149,7 @@
       "stars": 88,
       "forks": 5,
       "issues": 0,
-      "pull_requests": 397,
+      "pull_requests": 398,
       "contributors": 6
     },
     {
@@ -253,7 +253,7 @@
       "stars": 63,
       "forks": 3,
       "issues": 0,
-      "pull_requests": 96,
+      "pull_requests": 97,
       "contributors": 5
     },
     {
@@ -370,7 +370,7 @@
     },
     {
       "name": "yolo26",
-      "stars": 23,
+      "stars": 24,
       "forks": 3,
       "issues": 0,
       "pull_requests": 3,
@@ -378,7 +378,7 @@
     },
     {
       "name": "yolov8",
-      "stars": 16,
+      "stars": 17,
       "forks": 2,
       "issues": 0,
       "pull_requests": 3,
@@ -386,7 +386,7 @@
     },
     {
       "name": "yolo11",
-      "stars": 14,
+      "stars": 15,
       "forks": 2,
       "issues": 0,
       "pull_requests": 3,

--- a/data/google_analytics.json
+++ b/data/google_analytics.json
@@ -1,36 +1,36 @@
 {
   "property_id": "371754141",
-  "timestamp": "2026-07-24T03:12:43.782411Z",
+  "timestamp": "2026-07-25T03:12:15.933705Z",
   "periods": {
     "1d": {
-      "active_users": 856626,
-      "sessions": 7191644,
-      "events": 3570497421,
-      "avg_session_duration": 2811.049278755565
+      "active_users": 869632,
+      "sessions": 6337367,
+      "events": 3568549371,
+      "avg_session_duration": 3452.368913231045
     },
     "7d": {
-      "active_users": 4614988,
-      "sessions": 41700007,
-      "events": 22855817510,
-      "avg_session_duration": 2994.4714063574115
+      "active_users": 4699524,
+      "sessions": 42071852,
+      "events": 22957396234,
+      "avg_session_duration": 3024.551477234674
     },
     "30d": {
-      "active_users": 17634054,
-      "sessions": 179891491,
-      "events": 100717402762,
-      "avg_session_duration": 3071.0407559647174
+      "active_users": 17738897,
+      "sessions": 180519412,
+      "events": 100845429869,
+      "avg_session_duration": 3083.0709595369926
     },
     "90d": {
-      "active_users": 48456902,
-      "sessions": 505156909,
-      "events": 299510767071,
-      "avg_session_duration": 3236.5745754480713
+      "active_users": 48557318,
+      "sessions": 507255087,
+      "events": 299997465672,
+      "avg_session_duration": 3232.626306545982
     },
     "365d": {
-      "active_users": 133848429,
-      "sessions": 2933534412,
-      "events": 966926471055,
-      "avg_session_duration": 1949.7824665269043
+      "active_users": 134258130,
+      "sessions": 2933449619,
+      "events": 968850183759,
+      "avg_session_duration": 1953.7059689068265
     }
   }
 }

--- a/data/platform.json
+++ b/data/platform.json
@@ -4,6 +4,6 @@
   "total_images": 241908216,
   "total_models": 44599,
   "total_exports": 13611,
-  "total_annotations": 1212719644,
-  "timestamp": "2026-07-24T03:12:51.298932Z"
+  "total_annotations": 1211504910,
+  "timestamp": "2026-07-25T03:12:24.487702Z"
 }

--- a/data/pypi.json
+++ b/data/pypi.json
@@ -1,49 +1,49 @@
 {
-  "total_downloads": 305232143,
-  "total_last_month": 15141303,
-  "timestamp": "2026-07-24T03:12:42.881527Z",
+  "total_downloads": 305766476,
+  "total_last_month": 15089654,
+  "timestamp": "2026-07-25T03:12:14.277295Z",
   "packages": [
     {
       "package": "ultralytics",
-      "last_day": 299752,
-      "last_week": 2132933,
-      "last_month": 8784397,
-      "total": 207342474
+      "last_day": 266757,
+      "last_week": 2100931,
+      "last_month": 8732748,
+      "total": 207647269
     },
     {
       "package": "ultralytics-actions",
       "last_day": 302,
       "last_week": 1776,
       "last_month": 7592,
-      "total": 272806
+      "total": 273550
     },
     {
       "package": "ultralytics-thop",
       "last_day": 223548,
       "last_week": 1410809,
       "last_month": 6305183,
-      "total": 96044659
+      "total": 96271991
     },
     {
       "package": "hub-sdk",
       "last_day": 1270,
       "last_week": 6163,
       "last_month": 29285,
-      "total": 1253570
+      "total": 1254441
     },
     {
       "package": "mkdocs-ultralytics-plugin",
       "last_day": 515,
       "last_week": 4101,
       "last_month": 14772,
-      "total": 312983
+      "total": 313572
     },
     {
       "package": "ultralytics-autoimport",
       "last_day": 2,
       "last_week": 17,
       "last_month": 74,
-      "total": 5651
+      "total": 5653
     }
   ]
 }

--- a/data/reddit.json
+++ b/data/reddit.json
@@ -1,5 +1,5 @@
 {
   "subreddit": "ultralytics",
   "subscribers": 4100,
-  "timestamp": "2026-07-24T03:12:49.364464Z"
+  "timestamp": "2026-07-25T03:12:23.198118Z"
 }

--- a/data/summary.json
+++ b/data/summary.json
@@ -1,17 +1,17 @@
 {
-  "total_stars": 134599,
-  "total_forks": 33352,
-  "total_issues": 25608,
-  "total_pull_requests": 15505,
-  "total_downloads": 305232143,
-  "events_per_day": 3327897412,
-  "total_contributors": 1089,
+  "total_stars": 134668,
+  "total_forks": 33364,
+  "total_issues": 25611,
+  "total_pull_requests": 15545,
+  "total_downloads": 305766476,
+  "events_per_day": 3333305174,
+  "total_contributors": 1092,
   "reddit_subscribers": 4100,
   "platform_datasets": 52119,
-  "platform_annotations": 1212719644,
+  "platform_annotations": 1211504910,
   "platform_images": 241908216,
   "platform_projects": 19519,
   "platform_models": 44599,
   "platform_exports": 13611,
-  "timestamp": "2026-07-24T03:12:51.300707Z"
+  "timestamp": "2026-07-25T03:12:24.489275Z"
 }


### PR DESCRIPTION
Automated daily analytics update

## 🛠️ PR Summary

<sub>Made with ❤️ by [Ultralytics Actions](https://www.ultralytics.com/actions)</sub>

### 🌟 Summary

📈 Refreshes Ultralytics ecosystem metrics across GitHub, Google Analytics, PyPI, Reddit, and the Ultralytics Platform.

### 📊 Key Changes

- Updated GitHub organization statistics:
  - Stars increased to **134,668**.
  - Forks increased to **33,364**.
  - Contributors increased to **1,092**.
  - Pull requests increased to **15,545**.
- Updated Google Analytics activity for periods ranging from 1 day to 365 days.
- Updated PyPI package download totals to **305,766,476**, including refreshed statistics for `ultralytics` and related packages.
- Refreshed Ultralytics Platform metrics, including images, models, exports, and annotations.
- Updated Reddit subscriber and timestamp metadata.
- Synchronized `data/summary.json` with the latest collected metrics.

### 🎯 Purpose & Impact

- 📊 Keeps ecosystem dashboards and reports aligned with the latest daily activity.
- 🚀 Provides visibility into growth across repositories, package usage, website engagement, and community channels.
- 🔄 Improves consistency between detailed data files and the consolidated summary.
- ℹ️ This is a data-only update with no changes to model behavior, APIs, or user-facing software functionality.