### PR TITLE
Remove trailing slashes and update redirected Ultralytics URLs

### DIFF
--- a/.github/ISSUE_TEMPLATE/config.yml
+++ b/.github/ISSUE_TEMPLATE/config.yml
@@ -6,7 +6,7 @@ contact_links:
     url: https://github.com/ultralytics/stars#readme
     about: Data formats and automation notes for this repo
   - name: 💬 Forum
-    url: https://community.ultralytics.com/
+    url: https://community.ultralytics.com
     about: Ask the Ultralytics community for workflow help
   - name: 🎧 Discord
     url: https://ultralytics.com/discord

--- a/README.md
+++ b/README.md
@@ -1,4 +1,4 @@
-<a href="https://www.ultralytics.com/"><img src="https://raw.githubusercontent.com/ultralytics/assets/main/logo/Ultralytics_Logotype_Original.svg" width="320" alt="Ultralytics logo"></a>
+<a href="https://www.ultralytics.com"><img src="https://raw.githubusercontent.com/ultralytics/assets/main/logo/Ultralytics_Logotype_Original.svg" width="320" alt="Ultralytics logo"></a>
 
 # Ultralytics Analytics & Star Tracking ⭐️
 
@@ -6,8 +6,8 @@ Track GitHub stars, contributors, and PyPI downloads for [Ultralytics](https://g
 
 [![Ultralytics Actions](https://github.com/ultralytics/stars/actions/workflows/format.yml/badge.svg)](https://github.com/ultralytics/stars/actions/workflows/format.yml)
 [![Ultralytics Discord](https://img.shields.io/discord/1089800235347353640?logo=discord&logoColor=white&label=Discord&color=blue)](https://discord.com/invite/ultralytics)
-[![Ultralytics Forums](https://img.shields.io/discourse/users?server=https%3A%2F%2Fcommunity.ultralytics.com&logo=discourse&label=Forums&color=blue)](https://community.ultralytics.com/)
-[![Ultralytics Reddit](https://img.shields.io/reddit/subreddit-subscribers/ultralytics?style=flat&logo=reddit&logoColor=white&label=Reddit&color=blue)](https://reddit.com/r/ultralytics)
+[![Ultralytics Forums](https://img.shields.io/discourse/users?server=https%3A%2F%2Fcommunity.ultralytics.com&logo=discourse&label=Forums&color=blue)](https://community.ultralytics.com)
+[![Ultralytics Reddit](https://img.shields.io/reddit/subreddit-subscribers/ultralytics?style=flat&logo=reddit&logoColor=white&label=Reddit&color=blue)](https://www.reddit.com/r/ultralytics/)
 
 [![Update Analytics](https://github.com/ultralytics/stars/actions/workflows/analytics.yml/badge.svg)](https://github.com/ultralytics/stars/actions/workflows/analytics.yml)
 


### PR DESCRIPTION
Normalizes Ultralytics URLs in this repo's docs and issue-template config, and refreshes one permanently redirected link.

## Trailing slashes (3)

Removed the terminating path slash from every `ultralytics.com` / `*.ultralytics.com` URL:

- `README.md` — `https://www.ultralytics.com/` (logo link), `https://community.ultralytics.com/` (Forums badge link)
- `.github/ISSUE_TEMPLATE/config.yml` — `https://community.ultralytics.com/` (Forum contact link)

Applied with a regex self-tested on 17 positive and 23 negative cases before running, so path separators, emails (`web@ultralytics.com` in `analytics.yml`), templates (`{package}` f-strings in `fetch_stats.py`), ellipsis placeholders and non-Ultralytics hosts stayed untouched. Verified zero remaining Ultralytics URLs with a terminating slash afterwards.

## Redirects (1 accepted, rest rejected)

- `https://reddit.com/r/ultralytics` -> `https://www.reddit.com/r/ultralytics/` — accepted. Two chained `301`s (apex -> `www`, then Reddit's canonical subreddit slash), and it matches what the flagship `ultralytics/ultralytics` README already links to. Reddit is not an Ultralytics domain, so the trailing-slash rule does not apply to it.

Rejected / left alone:

- `https://ultralytics.com/discord`, `https://ultralytics.com/bilibili` — vanity shortlinks meant to stay redirects (the Discord target is an expiring invite).
- `https://portal.ultralytics.com` in `fetch_stats.py` — resolves to `/signin?redirect_url=%2F` for anonymous requests; it is the API base the script concatenates onto, so it must stay as is.
- `https://img.shields.io/discourse/users?server=https%3A%2F%2Fcommunity.ultralytics.com...` — URL-encoded parameter, kept byte-identical.
- `https://ultralytics.com/license` header lines — bot-owned strings written by Ultralytics Actions, already slash-free.
- `data/*.json` — bot-generated analytics output, excluded from the sweep (they contain no URLs).

No dead links found. All 24 markdown/HTML links in the repo resolve `200`.

## Validation

Diff is URL text only (4 lines across 2 files). All eight `.github` YAML files parse, and the three Python modules compile. This repo has no test suite or local lint config; formatting is applied by `ultralytics/actions` on PRs.

## 🛠️ PR Summary

<sub>Made with ❤️ by [Ultralytics Actions](https://www.ultralytics.com/actions)</sub>

### 🌟 Summary

Normalized Ultralytics URLs in the README and issue-template configuration and updated the Reddit link to its canonical URL.

### 📊 Key Changes

- Removed trailing slashes from the Ultralytics logo and community forum links in `README.md`.
- Removed the trailing slash from the community forum contact link in `.github/ISSUE_TEMPLATE/config.yml`.
- Changed the Reddit link from `https://reddit.com/r/ultralytics` to `https://www.reddit.com/r/ultralytics/`.
- Left redirects, API base URLs, and URL-encoded badge parameters unchanged.

### 🎯 Purpose & Impact

- README and issue-template links now use consistent Ultralytics URL formatting.
- The Reddit link points directly to Reddit’s canonical subreddit URL.
- No other repository behavior changes; analytics scripts and generated data are unaffected.