### PR TITLE
Track ultralytics-platform PyPI downloads

### DIFF
--- a/.github/workflows/analytics.yml
+++ b/.github/workflows/analytics.yml
@@ -13,7 +13,7 @@
 #   - All-time total downloads per package and org-wide (via pepy.tech API with auth)
 #   - Daily, weekly, and monthly download counts (via pypistats.org API)
 #   - Tracked packages: ultralytics, ultralytics-actions, ultralytics-thop,
-#     hub-sdk, mkdocs-ultralytics-plugin, ultralytics-autoimport
+#     hub-sdk, mkdocs-ultralytics-plugin, ultralytics-autoimport, ultralytics-platform
 #
 # Google Analytics Data (data/google_analytics.json):
 #   - Active users, sessions, and page views (30-day window)

--- a/README.md
+++ b/README.md
@@ -46,6 +46,7 @@ https://raw.githubusercontent.com/ultralytics/stars/main/data/pypi.json
 - `hub-sdk` - Ultralytics HUB SDK
 - `mkdocs-ultralytics-plugin` - Documentation plugin
 - `ultralytics-autoimport` - Auto-import utilities
+- `ultralytics-platform` - Ultralytics Platform Python SDK
 
 **Fields:**
 

--- a/fetch_stats.py
+++ b/fetch_stats.py
@@ -338,6 +338,7 @@ if __name__ == "__main__":
         "hub-sdk",
         "mkdocs-ultralytics-plugin",
         "ultralytics-autoimport",
+        "ultralytics-platform",
     ]
     pypi_output = BASE_DIR / "data/pypi.json"
     pepy_api_key = os.getenv("PEPY_API_KEY")


### PR DESCRIPTION
## Summary

- include ultralytics-platform in daily PyPI download aggregation
- document the seventh tracked package in the README and analytics workflow

Portal already consumes every package row and the aggregate totals from data/pypi.json, so no Portal code change is required.

## Validation

- python3 -m compileall -q fetch_stats.py utils.py count_stars.py
- deterministic fetch_pypi_stats smoke test covering all seven packages
- git diff --check
- verified ultralytics-platform 0.1.20 is live on PyPI

## 🛠️ PR Summary

<sub>Made with ❤️ by [Ultralytics Actions](https://www.ultralytics.com/actions)</sub>

### 🌟 Summary

Added `ultralytics-platform` to the PyPI download aggregation and documented it as the seventh tracked package.

### 📊 Key Changes

- Updated `fetch_pypi_stats()` to include the `ultralytics-platform` package in `data/pypi.json` generation.
- Added `ultralytics-platform` to the tracked-package list in the analytics workflow documentation.
- Documented `ultralytics-platform` as the Ultralytics Platform Python SDK in the README.

### 🎯 Purpose & Impact

- PyPI analytics now includes download data for `ultralytics-platform` alongside the six existing packages.
- No Portal code change is required because it already consumes package rows and aggregate totals from `data/pypi.json`.