### PR TITLE
Update Ultralytics analytics

### DIFF
--- a/data/github.json
+++ b/data/github.json
@@ -1,16 +1,16 @@
 {
   "org": "ultralytics",
-  "total_stars": 136438,
+  "total_stars": 136441,
   "total_forks": 33571,
   "total_issues": 25704,
-  "total_pull_requests": 16840,
+  "total_pull_requests": 16841,
   "total_contributors": 1158,
   "public_repos": 52,
-  "timestamp": "2026-08-30T01:01:21.481939Z",
+  "timestamp": "2026-08-30T02:29:09.533204Z",
   "repos": [
     {
       "name": "ultralytics",
-      "stars": 61074,
+      "stars": 61077,
       "forks": 11650,
       "issues": 12907,
       "pull_requests": 7366,
@@ -141,7 +141,7 @@
       "stars": 93,
       "forks": 6,
       "issues": 0,
-      "pull_requests": 441,
+      "pull_requests": 442,
       "contributors": 6
     },
     {

--- a/data/google_analytics.json
+++ b/data/google_analytics.json
@@ -1,6 +1,6 @@
 {
   "property_id": "371754141",
-  "timestamp": "2026-08-30T01:02:04.317034Z",
+  "timestamp": "2026-08-30T02:29:30.055003Z",
   "periods": {
     "1d": {
       "active_users": 1440179,

--- a/data/platform.json
+++ b/data/platform.json
@@ -5,5 +5,5 @@
   "total_models": 57085,
   "total_exports": 17393,
   "total_annotations": 1456312288,
-  "timestamp": "2026-08-30T01:02:14.243734Z"
+  "timestamp": "2026-08-30T02:29:33.783627Z"
 }

--- a/data/pypi.json
+++ b/data/pypi.json
@@ -1,55 +1,55 @@
 {
   "total_downloads": 323748287,
-  "total_last_month": 14696901,
-  "timestamp": "2026-08-30T01:02:03.228036Z",
+  "total_last_month": 14408368,
+  "timestamp": "2026-08-30T02:29:29.055680Z",
   "packages": [
     {
       "package": "ultralytics",
-      "last_day": 137252,
-      "last_week": 1252843,
-      "last_month": 7572843,
+      "last_day": 97353,
+      "last_week": 1152924,
+      "last_month": 7378577,
       "total": 217107920
     },
     {
       "package": "ultralytics-actions",
-      "last_day": 130,
-      "last_week": 995,
-      "last_month": 5917,
+      "last_day": 41,
+      "last_week": 883,
+      "last_month": 5724,
       "total": 294174
     },
     {
       "package": "ultralytics-thop",
-      "last_day": 124407,
-      "last_week": 1024197,
-      "last_month": 5888265,
+      "last_day": 92939,
+      "last_week": 960832,
+      "last_month": 5753126,
       "total": 103500114
     },
     {
       "package": "hub-sdk",
-      "last_day": 391,
-      "last_week": 3226,
-      "last_month": 15210,
+      "last_day": 109,
+      "last_week": 3019,
+      "last_month": 14759,
       "total": 1275396
     },
     {
       "package": "mkdocs-ultralytics-plugin",
-      "last_day": 56,
-      "last_week": 478,
-      "last_month": 4893,
+      "last_day": 22,
+      "last_week": 419,
+      "last_month": 4384,
       "total": 324552
     },
     {
       "package": "ultralytics-autoimport",
-      "last_day": 25,
-      "last_week": 40,
+      "last_day": 2,
+      "last_week": 41,
       "last_month": 223,
       "total": 6326
     },
     {
       "package": "ultralytics-platform",
-      "last_day": 48247,
-      "last_week": 471957,
-      "last_month": 1209550,
+      "last_day": 42025,
+      "last_week": 434210,
+      "last_month": 1251575,
       "total": 1239805
     }
   ]

--- a/data/reddit.json
+++ b/data/reddit.json
@@ -1,5 +1,5 @@
 {
   "subreddit": "ultralytics",
   "subscribers": 4600,
-  "timestamp": "2026-08-30T01:02:11.502571Z"
+  "timestamp": "2026-08-30T02:29:33.450870Z"
 }

--- a/data/summary.json
+++ b/data/summary.json
@@ -1,8 +1,8 @@
 {
-  "total_stars": 136438,
+  "total_stars": 136441,
   "total_forks": 33571,
   "total_issues": 25704,
-  "total_pull_requests": 16840,
+  "total_pull_requests": 16841,
   "total_downloads": 323748287,
   "events_per_day": 3567730605,
   "total_contributors": 1158,
@@ -13,5 +13,5 @@
   "platform_projects": 24055,
   "platform_models": 57085,
   "platform_exports": 17393,
-  "timestamp": "2026-08-30T01:02:14.245280Z"
+  "timestamp": "2026-08-30T02:29:33.785304Z"
 }


### PR DESCRIPTION
Automated daily analytics update

## 🛠️ PR Summary

<sub>Made with ❤️ by [Ultralytics Actions](https://www.ultralytics.com/actions)</sub>

### 🌟 Summary

Refreshed GitHub, Google Analytics, Platform, PyPI, Reddit, and aggregate summary metrics with newer analytics snapshots.

### 📊 Key Changes

- Updated GitHub totals to 136,441 stars and 16,841 pull requests, including repository-level star and pull request counts.
- Refreshed PyPI download metrics for all tracked packages, including daily, weekly, monthly, and total downloads.
- Updated timestamps for Google Analytics, Ultralytics Platform, Reddit, GitHub, PyPI, and the aggregate summary data.
- Updated the aggregate summary to reflect the new GitHub star and pull request totals.

### 🎯 Purpose & Impact

- Analytics views and reports using these JSON files now display the latest recorded metrics; no application or package behavior changed.